### PR TITLE
Event system reworked

### DIFF
--- a/Assets/Scenes/EventCallbackScene/DeathListener.cs
+++ b/Assets/Scenes/EventCallbackScene/DeathListener.cs
@@ -10,7 +10,7 @@ namespace EventCallbacks
         // Use this for initialization
         void Start()
         {
-            EventSystem.Current.RegisterListener<UnitDeathEventInfo>(OnUnitDied);
+            EventSystem.Register<UnitDeathEventInfo>(OnUnitDied);
         }
 
         // Update is called once per frame

--- a/Assets/Scenes/EventCallbackScene/Health.cs
+++ b/Assets/Scenes/EventCallbackScene/Health.cs
@@ -30,9 +30,7 @@ namespace EventCallbacks
             udei.EventDescription = "Unit "+ gameObject.name +" has died.";
             udei.UnitGO = gameObject;
 
-            EventSystem.Current.FireEvent(
-                udei
-                );
+            EventSystem.FireEvent(udei);
 
             Destroy(gameObject);
         }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -420,6 +420,7 @@ PlayerSettings:
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchSupportedNpadStyles: 3
+  switchNativeFsCacheSize: 32
   switchSocketConfigEnabled: 0
   switchTcpInitialSendBufferSize: 32
   switchTcpInitialReceiveBufferSize: 64
@@ -581,7 +582,7 @@ PlayerSettings:
   incrementalIl2cppBuild: {}
   allowUnsafeCode: 0
   additionalIl2CppArgs: 
-  scriptingRuntimeVersion: 0
+  scriptingRuntimeVersion: 1
   apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2018.1.0f2
+m_EditorVersion: 2018.1.3f1


### PR DESCRIPTION
Not expecting this to get merged as it's changing it a bit too much, but this is the only way around the generic issue that I could see - thought you might be interested! (Something to do with contravariance/covariance?)

It's still not fully generic as I don't think that's possible (would love to be proved wrong) but it does move the necessary casting to the point at which the event is registered and fired, not one per execution of the event as the workaround was doing, so probably a tiny bit more performant but not tested that!