### PR TITLE
Using Reflection

### DIFF
--- a/Assets/Scenes/EventCallbackScene/EventSystem.cs
+++ b/Assets/Scenes/EventCallbackScene/EventSystem.cs
@@ -1,12 +1,17 @@
-﻿using System.Collections;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace EventCallbacks
 {
+    public class Handler
+    {
+        public object Target { get; set; }
+        public System.Reflection.MethodInfo Method { get; set; }
+    }
+
     public class EventSystem : MonoBehaviour
     {
-
         // Use this for initialization
         void OnEnable()
         {
@@ -28,48 +33,46 @@ namespace EventCallbacks
         }
 
         delegate void EventListener(EventInfo ei);
-        Dictionary<System.Type, List<EventListener>> eventListeners;
+        Dictionary<Type, List<Handler>> eventListeners;
 
-        public void RegisterListener<T>(System.Action<T> listener) where T : EventInfo
+        public void RegisterListener<T>(Action<T> listener) where T : EventInfo
         {
-            System.Type eventType = typeof(T);
+            var target = listener.Target;
+            var method = listener.Method;
+
+            Type eventType = typeof(T);
             if (eventListeners == null)
             {
-                eventListeners = new Dictionary<System.Type, List<EventListener>>();
+                eventListeners = new Dictionary<Type, List<Handler>>();
             }
 
-            if(eventListeners.ContainsKey(eventType) == false || eventListeners[eventType] == null)
+            if (eventListeners.ContainsKey(eventType) == false || eventListeners[eventType] == null)
             {
-                eventListeners[eventType] = new List<EventListener>();
+                eventListeners[eventType] = new List<Handler>();
             }
 
-            // Wrap a type converstion around the event listener
-            // I'm betting someone better at C# generic syntax
-            // can find a way around this.
-            EventListener wrapper = (ei) => { listener((T)ei); };
-
-            eventListeners[eventType].Add(wrapper);
+            eventListeners[eventType].Add(new Handler { Target = target, Method = method });
         }
 
-        public void UnregisterListener<T>(System.Action<T> listener) where T : EventInfo
+        public void UnregisterListener<T>(Action<T> listener) where T : EventInfo
         {
-            // TODO
+            var eventType = typeof(T);
+            eventListeners[eventType].RemoveAll(l => l.Target == listener.Target && l.Method == listener.Method);
         }
 
         public void FireEvent(EventInfo eventInfo)
         {
-            System.Type trueEventInfoClass = eventInfo.GetType();
+            Type trueEventInfoClass = eventInfo.GetType();
             if (eventListeners == null || eventListeners[trueEventInfoClass] == null)
             {
                 // No one is listening, we are done.
                 return;
             }
 
-            foreach(EventListener el in eventListeners[trueEventInfoClass])
+            foreach (Handler el in eventListeners[trueEventInfoClass])
             {
-                el( eventInfo );
+                el.Method.Invoke(el.Target, new[] { eventInfo });
             }
         }
-
     }
 }

--- a/Assets/Scenes/EventCallbackScene/EventSystem.cs
+++ b/Assets/Scenes/EventCallbackScene/EventSystem.cs
@@ -4,12 +4,6 @@ using UnityEngine;
 
 namespace EventCallbacks
 {
-    public class Handler
-    {
-        public object Target { get; set; }
-        public System.Reflection.MethodInfo Method { get; set; }
-    }
-
     public class EventSystem : MonoBehaviour
     {
         // Use this for initialization
@@ -73,6 +67,12 @@ namespace EventCallbacks
             {
                 el.Method.Invoke(el.Target, new[] { eventInfo });
             }
+        }
+        
+        public class Handler
+        {
+            public object Target { get; set; }
+            public System.Reflection.MethodInfo Method { get; set; }
         }
     }
 }


### PR DESCRIPTION
This method instead uses reflection, which is likely faster, but probably negligibly so. My biggest concern with the current code was using the typecast that way - I suspect you might get invalid cast exceptions as you register more listeners.

I do like the idea of encapsulating within the Event<T> itself, but it does limit scalability and flexibility of a central manager (e.g. a ServiceBus).

This solution is a minor change, and I have kept with the conventions of the existing code as much as possible (but have implemented the unregister also). There are a number of design changes I would probably make overall, but the changes fit with the current model. 